### PR TITLE
add fluent query mechanism

### DIFF
--- a/test/fluent.test.js
+++ b/test/fluent.test.js
@@ -1,0 +1,51 @@
+import { assertEquals, assertNotEquals } from "https://deno.land/std@0.126.0/testing/asserts.ts";
+import {Graph} from '../src/graph.js';
+
+
+let r = new Graph()
+{
+  let m1 = r.addNode('Employee',{name:'A. B. Boss'})
+  let s1 = r.addNode('Options',{name:'Series B'}); r.addRel('Bonus',m1,s1,{shares:200,vesting:'2024-2-1'})
+  let e1 = r.addNode('Employee',{name:'C. D. Programmer'}); r.addRel('Manager',e1,m1,{role:'Hiring'})
+  let s2 = r.addNode('Options',{name:'Series C'}); r.addRel('Incentive',e1,s2,{shares:100,vesting:'2025-5-1'})
+  let e2 = r.addNode('Employee',{name:'E. F. Consultant'}); r.addRel('Manager',e2,m1,{role:'Acting'})
+}
+console.log(r)
+
+Deno.test("All Employees", () => {
+  let names = r.n('Employee').props()
+  let expect = ['A. B. Boss','C. D. Programmer','E. F. Consultant']
+    assertEquals(names,expect);
+})
+
+Deno.test("All Managed Employees", () => {
+  let names = r.n('Employee').o('Manager').t().props()
+  let expect = ['A. B. Boss']
+    assertEquals(names,expect);
+})
+
+Deno.test("All Manager Roles", () => {
+  let roles = r.n('Employee').i('Manager').props('role')
+  let expect = ['Acting','Hiring']
+    assertEquals(roles,expect);
+})
+
+Deno.test("All Managers", () => {
+  let roles = r.n('Employee').i('Manager').f().props()
+  let expect = ['C. D. Programmer','E. F. Consultant']
+    assertEquals(roles,expect);
+})
+
+Deno.test("Managers of Employees with Options", () => {
+  let issues = r.n('Options')
+    assertEquals(issues.props(), ['Series B','Series C'])
+  let incentive = issues.i()
+    assertEquals(incentive.types(),['Bonus','Incentive'])
+    assertEquals(incentive.props('shares'),[100,200])
+  let holders = incentive.f('Employee')
+    assertEquals(holders.props(), ['A. B. Boss','C. D. Programmer'])
+  let managers = holders.o('Manager').t()
+    assertEquals(managers.props(),['A. B. Boss']);
+})
+
+


### PR DESCRIPTION
Wrap indexes into nodes (nids) and indexes into rels (rids) in classes, Nodes and Rels respectively.
Nodes offers access to Rels based on the nids they hold and the fluent functions i() and o() for inward and outward relations.
Rels offers access to Nodes based on the rids they hold and the fluent functions f() and t() for from and to nodes.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/12127/155248578-8e5f6d44-8026-4505-8b98-d7911f567786.png">

Notice that Options are related to Employees by relations of different types but we are able to query for these using an non-specific i() and then discover what types it matches. This shows that we solve the problem identified with our previous "macros" with similar names.

http://ward.dojo.fed.wiki/cypher-macros.html

<img width="447" alt="image" src="https://user-images.githubusercontent.com/12127/155248977-55beffdd-076b-43ca-8123-989128dc448b.png">
