### PR TITLE
dynamic import of json not yet widespread

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -48,10 +48,10 @@ export class Graph {
     return Graph.load(obj)
   }
 
-  static async import(path) {
-    let module = await import(path, {assert: {type: "json"}})
-    return Graph.load(module.default)
-  }
+  // static async import(path) {
+  //   let module = await import(path, {assert: {type: "json"}})
+  //   return Graph.load(module.default)
+  // }
 
   n(type=null, props={}) {
     let nids = Object.keys(this.nodes).map(key => +key)

--- a/test/io.test.js
+++ b/test/io.test.js
@@ -80,11 +80,11 @@ import {Graph} from '../src/graph.js';
     assertEquals(g.tally(), tally)
   })
 
-  Deno.test("Import from Path", async () => {
-    // note: path relative to executable as with other imports
-    let path = '../sample/data/mock-graph.json'
-    let g = await Graph.import(path)
-    assertEquals(g.tally(), tally)
-  })
+  // Deno.test("Import from Path", async () => {
+  //   // note: path relative to executable as with other imports
+  //   let path = '../sample/data/mock-graph.json'
+  //   let g = await Graph.import(path)
+  //   assertEquals(g.tally(), tally)
+  // })
 }
 


### PR DESCRIPTION
Graph does not load under Firefox browser. 
We will delay offering this feature until supported by major browser.
Work-around is to fetch and parse without module treatment.

Discussion in denoland.
https://github.com/denoland/deno/issues/5633
https://github.com/denoland/deno/issues/7623

Deno 1.17 release notes.
https://deno.com/blog/v1.17#import-assertions-and-json-modules

V8 developers suggest assertions addresses security concern.
https://v8.dev/features/import-assertions

TC39 
https://github.com/tc39/proposal-import-assertions