### PR TITLE
add map over nodes and rels

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -109,6 +109,15 @@ export class Nodes {
     })
     return new Nodes(this.graph,nids)
   }
+
+  map(f) {
+    let nodes = this.graph.nodes
+    let result = this.nids.map(nid => {
+      let node = nodes[nid]
+      return f(node)
+    })
+    return result
+  }
 }
 
 export class Rels {
@@ -152,4 +161,12 @@ export class Rels {
     return new Rels(this.graph,rids)
   }
 
+  map(f) {
+    let rels = this.graph.rels
+    let result = this.rids.map(rid => {
+      let rel = rels[rid]
+      return f(rel)
+    })
+    return result
+  }
 }

--- a/test/fluent.test.js
+++ b/test/fluent.test.js
@@ -53,8 +53,20 @@ Deno.test("All Nodes With B in Name", () => {
     assertEquals(bees.props('name'), ['A. B. Boss','Series B'])
 })
 
+Deno.test("Map over Nodes With B in Name", () => {
+  let bees = r.n().filter((type,props) => props['name'].includes('B'))
+  let names = bees.map(node => node.props['name'])
+    assertEquals(names, ['A. B. Boss','Series B'])
+})
+
 Deno.test("All Rels With A in Role", () => {
   let temps = r.n('Employee').i('Manager').filter((type,props) => props['role'].includes('A'))
     assertEquals(temps.props('role'),['Acting'])
+})
+
+Deno.test("Map over Rels With A in Role", () => {
+  let temps = r.n('Employee').i('Manager').filter((type,props) => props['role'].includes('A'))
+  let roles = temps.map(rel => rel.props['role'])
+    assertEquals(roles,['Acting'])
 })
 


### PR DESCRIPTION
Map is similar to filter in how they retrieve elements and differ in how they present the elements to the function argument.

We found our filter tests and added map tests in the same test file. We watched these fail and then consulted the filter implementations and chose map implementations that followed the same logic.

Kelley and I examined the use of nids and rids in the navigator.html script. This is  how we selected map as a good next step expanding the Nodes and Rels fluent interface.

```

// table

      let nodes =lineup[line].data.nodes
      let rows = nodes.nids.map(nid => `<tr>
        <td>${nodes.graph.nodes[nid].in.join(', ')}
        <td>${nodes.graph.nodes[nid].props['name']}
        <td>${nodes.graph.nodes[nid].out.join(', ')}`).join("\n")


nodes.map(node => `${node.in ...}  ${node.props[]}  ${node.out ...}`)


// choice

      let have = lineup[line].data.nodes
      div.innerHTML += `<table><tr>
        <td>${have.i().rids.map(rid => have.graph.rels[rid].type).filter(uniq).join("<br")}</td>
        <td>${have.o().rids.map(rid => have.graph.rels[rid].type).filter(uniq).join("<br")}</td>
      </table>`

rels.map(rel => rel.type).filter(uniq).join ...
```