### PR TITLE
add size and tally to Nodes and Rels

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -101,6 +101,15 @@ export class Nodes {
     return this.nids.map(nid => this.graph.nodes[nid].type).filter(uniq).sort()
   }
 
+  tally(){
+    const tally = list => list.reduce((s,e)=>{s[e.type] = s[e.type] ? s[e.type]+1 : 1; return s}, {});
+    return { nodes:tally(this.nids.map(nid => this.graph.nodes[nid]))};
+  }
+
+  size(){
+    return this.nids.length
+  }
+
   filter(f) {
     let nodes = this.graph.nodes
     let nids = this.nids.filter(nid => {
@@ -150,6 +159,15 @@ export class Rels {
 
   types() {
     return this.rids.map(rid => this.graph.rels[rid].type).filter(uniq).sort()
+  }
+
+  tally(){
+    const tally = list => list.reduce((s,e)=>{s[e.type] = s[e.type] ? s[e.type]+1 : 1; return s}, {});
+    return { rels:tally(this.rids.map(nid => this.graph.rels[nid]))};
+  }
+
+  size(){
+    return this.rids.length
   }
 
   filter(f) {

--- a/test/fluent.test.js
+++ b/test/fluent.test.js
@@ -48,6 +48,16 @@ Deno.test("Managers of Employees with Options", () => {
     assertEquals(managers.props(),['A. B. Boss']);
 })
 
+Deno.test("Size of Set of Nodes or Rels", () => {
+  assertEquals(r.n().size(), 5)
+  assertEquals(r.n().i().size(), 4)
+})
+
+Deno.test("Tally of Set of Nodes or Rels", () => {
+  assertEquals(r.n().tally(),{nodes: {Employee: 3, Options: 2}})
+  assertEquals(r.n().i().tally(),{rels: {Bonus: 1, Incentive: 1, Manager: 2}})
+})
+
 Deno.test("All Nodes With B in Name", () => {
   let bees = r.n().filter((type,props) => props['name'].includes('B'))
     assertEquals(bees.props('name'), ['A. B. Boss','Series B'])

--- a/test/fluent.test.js
+++ b/test/fluent.test.js
@@ -2,42 +2,42 @@ import { assertEquals, assertNotEquals } from "https://deno.land/std@0.126.0/tes
 import {Graph} from '../src/graph.js';
 
 
-let r = new Graph()
+let g = new Graph()
 {
-  let m1 = r.addNode('Employee',{name:'A. B. Boss'})
-  let s1 = r.addNode('Options',{name:'Series B'}); r.addRel('Bonus',m1,s1,{shares:200,vesting:'2024-2-1'})
-  let e1 = r.addNode('Employee',{name:'C. D. Programmer'}); r.addRel('Manager',e1,m1,{role:'Hiring'})
-  let s2 = r.addNode('Options',{name:'Series C'}); r.addRel('Incentive',e1,s2,{shares:100,vesting:'2025-5-1'})
-  let e2 = r.addNode('Employee',{name:'E. F. Consultant'}); r.addRel('Manager',e2,m1,{role:'Acting'})
+  let m1 = g.addNode('Employee',{name:'A. B. Boss'})
+  let s1 = g.addNode('Options',{name:'Series B'}); g.addRel('Bonus',m1,s1,{shares:200,vesting:'2024-2-1'})
+  let e1 = g.addNode('Employee',{name:'C. D. Programmer'}); g.addRel('Manager',e1,m1,{role:'Hiring'})
+  let s2 = g.addNode('Options',{name:'Series C'}); g.addRel('Incentive',e1,s2,{shares:100,vesting:'2025-5-1'})
+  let e2 = g.addNode('Employee',{name:'E. F. Consultant'}); g.addRel('Manager',e2,m1,{role:'Acting'})
 }
-console.log(r)
+console.log(g)
 
 Deno.test("All Employees", () => {
-  let names = r.n('Employee').props()
+  let names = g.n('Employee').props()
   let expect = ['A. B. Boss','C. D. Programmer','E. F. Consultant']
     assertEquals(names,expect);
 })
 
 Deno.test("All Managed Employees", () => {
-  let names = r.n('Employee').o('Manager').t().props()
+  let names = g.n('Employee').o('Manager').t().props()
   let expect = ['A. B. Boss']
     assertEquals(names,expect);
 })
 
 Deno.test("All Manager Roles", () => {
-  let roles = r.n('Employee').i('Manager').props('role')
+  let roles = g.n('Employee').i('Manager').props('role')
   let expect = ['Acting','Hiring']
     assertEquals(roles,expect);
 })
 
 Deno.test("All Managers", () => {
-  let roles = r.n('Employee').i('Manager').f().props()
+  let roles = g.n('Employee').i('Manager').f().props()
   let expect = ['C. D. Programmer','E. F. Consultant']
     assertEquals(roles,expect);
 })
 
 Deno.test("Managers of Employees with Options", () => {
-  let issues = r.n('Options')
+  let issues = g.n('Options')
     assertEquals(issues.props(), ['Series B','Series C'])
   let incentive = issues.i()
     assertEquals(incentive.types(),['Bonus','Incentive'])
@@ -49,33 +49,33 @@ Deno.test("Managers of Employees with Options", () => {
 })
 
 Deno.test("Size of Set of Nodes or Rels", () => {
-  assertEquals(r.n().size(), 5)
-  assertEquals(r.n().i().size(), 4)
+  assertEquals(g.n().size(), 5)
+  assertEquals(g.n().i().size(), 4)
 })
 
 Deno.test("Tally of Set of Nodes or Rels", () => {
-  assertEquals(r.n().tally(),{nodes: {Employee: 3, Options: 2}})
-  assertEquals(r.n().i().tally(),{rels: {Bonus: 1, Incentive: 1, Manager: 2}})
+  assertEquals(g.n().tally(),{nodes: {Employee: 3, Options: 2}})
+  assertEquals(g.n().i().tally(),{rels: {Bonus: 1, Incentive: 1, Manager: 2}})
 })
 
 Deno.test("All Nodes With B in Name", () => {
-  let bees = r.n().filter((type,props) => props['name'].includes('B'))
+  let bees = g.n().filter((type,props) => props['name'].includes('B'))
     assertEquals(bees.props('name'), ['A. B. Boss','Series B'])
 })
 
 Deno.test("Map over Nodes With B in Name", () => {
-  let bees = r.n().filter((type,props) => props['name'].includes('B'))
+  let bees = g.n().filter((type,props) => props['name'].includes('B'))
   let names = bees.map(node => node.props['name'])
     assertEquals(names, ['A. B. Boss','Series B'])
 })
 
 Deno.test("All Rels With A in Role", () => {
-  let temps = r.n('Employee').i('Manager').filter((type,props) => props['role'].includes('A'))
+  let temps = g.n('Employee').i('Manager').filter((type,props) => props['role'].includes('A'))
     assertEquals(temps.props('role'),['Acting'])
 })
 
 Deno.test("Map over Rels With A in Role", () => {
-  let temps = r.n('Employee').i('Manager').filter((type,props) => props['role'].includes('A'))
+  let temps = g.n('Employee').i('Manager').filter((type,props) => props['role'].includes('A'))
   let roles = temps.map(rel => rel.props['role'])
     assertEquals(roles,['Acting'])
 })


### PR DESCRIPTION
These two accessing functions are offered by Graph but will simplify debug reporting if they were also available in our extracted subsets.

Note: the implementation of tally might be subject to simplification but I felt it more important to use the same tally mechanism in all cases.