### PR TITLE
Add serialize method to graph

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -59,6 +59,11 @@ export class Graph {
     for (let key in props) nids = nids.filter(nid => this.nodes[nid].props[key] == props[key])
     return new Nodes(this, nids)
   }
+
+  stringify(...args) {
+    let obj = { nodes: this.nodes, rels: this.rels }
+    return JSON.stringify(obj, ...args)
+  }
 }
 
 export class Nodes {

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -46,3 +46,20 @@ Deno.test("Adding Three Nodes And One Rels Yields Size Four", () => {
   assertEquals(g.tally().rels['SampleRelType'], 1 );
 });
 
+Deno.test("Serialize graph", () => {
+  let g = new Graph();
+  let marc = g.addNode("Person", { name: "Marc" });
+  let ward = g.addNode("Person", { name: "Ward" });
+  let rel = g.addRel("Friend", marc, ward);
+  assertEquals(
+    g.stringify(),
+    '{"nodes":[{"type":"Person","in":[],"out":[0],"props":{"name":"Marc"}},{"type":"Person","in":[0],"out":[],"props":{"name":"Ward"}}],"rels":[{"type":"Friend","from":0,"to":1,"props":{}}]}',
+  );
+});
+
+Deno.test("Serialize graph with arguments", () => {
+  let g = new Graph();
+  let ward = g.addNode("Person", { name: "Ward" });
+  let stringifiedGraph = g.stringify(null, 2)
+  assertEquals(stringifiedGraph.split("\n").length, 13);
+});


### PR DESCRIPTION
This pull requests add a method named `stringify` to the graph class to serialize the instance to a string of json. The method accepts the same optional parameters as `JSON.stringify`.

:pear: This was accomplished while pairing with @WardCunningham

I matched the style of the existing code, but I notice that the repo prefers `const` to `let`.