### PR TITLE
Update stringify test to be more explicit about arguments

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -60,6 +60,12 @@ export class Graph {
     return new Nodes(this, nids)
   }
 
+  /**
+   * Converts a graph to a JavaScript Object Notation (JSON) string using JSON.stringify.
+   @param - replacer A function that transforms the results.
+   @param - space Adds indentation, white space, and line break characters to the return-
+   * @returns {string} JSON string containing serialized graph
+  */
   stringify(...args) {
     let obj = { nodes: this.nodes, rels: this.rels }
     return JSON.stringify(obj, ...args)

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -57,9 +57,10 @@ Deno.test("Serialize graph", () => {
   );
 });
 
-Deno.test("Serialize graph with arguments", () => {
+Deno.test("Serialize graph with arbitrary JSON.stringify arguments", () => {
   let g = new Graph();
   let ward = g.addNode("Person", { name: "Ward" });
+
   let stringifiedGraph = g.stringify(null, 2)
-  assertEquals(stringifiedGraph.split("\n").length, 13);
+  assertEquals(stringifiedGraph, '{\n  "nodes": [\n    {\n      "type": "Person",\n      "in": [],\n      "out": [],\n      "props": {\n        "name": "Ward"\n      }\n    }\n  ],\n  "rels": []\n}')
 });


### PR DESCRIPTION
Updates the stringify test to make it more clear what is happening with the `JSON.stringify` usage. I've made the two tests more aligned and included the whitespace in the second test.

@mkelleyharris I understand what you are saying about the arcane parameters accepted by the stringify function. `null, 2` makes no sense to anyone. I'd also hesitate to lock down the whitespace change in a specific keyword as there is more functionality that potentially could be used.