### PR TITLE
optional match

### DIFF
--- a/cypher/run.js
+++ b/cypher/run.js
@@ -15,7 +15,12 @@ match (mngr: Employee {name: "B. B. Clark"}) -[]- (:Project) -[]- (:Service) -[:
 
 for (const query of queries.split(/\n+/)) {
   console.error(query)
-  console.table(format(search(graph,query)))
+  console.table(format(graph.search(query,{log})))
+}
+
+function log(text) {
+  const trace = text.replace(/\%c/,"ZZZ<").replace(/\%c/,">ZZZ").replace(/ZZZ/g,"%c")
+  console.log(trace,"color:red","color:black")
 }
 
 function format(results) {

--- a/cypher/run.js
+++ b/cypher/run.js
@@ -2,7 +2,6 @@
 // deno run --allow-read run.js
 
 import { Graph } from '../src/graph.js'
-import { search } from './cypher.js'
 
 const graph = await Graph.read('../sample/data/mock-graph.json')
 console.error(graph.tally())
@@ -11,16 +10,21 @@ const queries =
 `match (mngr: Employee {name: "B. B. Clark"}) -[:Manager]-> (stuff)
 match (mngr: Employee {name: "B. B. Clark"}) <-[:Manager]- (stuff)
 match (mngr: Employee {name: "B. B. Clark"}) -[:Manager]- (stuff)
-match (mngr: Employee {name: "B. B. Clark"}) -[]- (:Project) -[]- (:Service) -[:Traffic{environment:"production"}]-> (stat)`
+match (mngr: Employee {name: "B. B. Clark"}) -[]- (:Project) -[]- (:Service) -[:Traffic{environment:"production"}]-> (stat)
+optional match (mngr: Employee {name: "H. G. Cunningham"})`
 
 for (const query of queries.split(/\n+/)) {
   console.error(query)
   console.table(format(graph.search(query,{log})))
 }
 
-function log(text) {
-  const trace = text.replace(/\%c/,"ZZZ<").replace(/\%c/,">ZZZ").replace(/ZZZ/g,"%c")
-  console.log(trace,"color:red","color:black")
+function log(...args) {
+  if(args[0].match(/%c/)) {
+    const trace = args[0].replace(/\%c/,"ZZZ<").replace(/\%c/,">ZZZ").replace(/ZZZ/g,"%c")
+    console.log(trace,"color:red","color:black")
+  } else {
+    console.log(...args)
+  }
 }
 
 function format(results) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -76,9 +76,9 @@ export class Graph {
 
   search (query, opt={}) {
     const tree = cypher.parse(query,opt.log)
-    // console.dir(tree, {depth:15})
-    const code = cypher.gen(0,tree[0][0],{})
-    // console.log(code)
+    console.dir(tree, {depth:15})
+    const code = cypher.gen(0,tree[0][0],{},opt.log)
+    console.log(code)
     cypher.check(this.tally(),code,opt.errors)
     return cypher.apply(this, code)
   }

--- a/src/graph.js
+++ b/src/graph.js
@@ -75,7 +75,7 @@ export class Graph {
 
 
   search (query, opt={}) {
-    const tree = cypher.parse(query)
+    const tree = cypher.parse(query,opt.log)
     // console.dir(tree, {depth:15})
     const code = cypher.gen(0,tree[0][0],{})
     // console.log(code)


### PR DESCRIPTION
We add parse rules to recognize an optional match.
```
optional match (mngr: Employee {name: "H. G. Cunningham"})
```
This is presently producing `optnl` in place of `match`.
```
 query
 | optnl
 | | node
 | | | elem
 | | | | bind "mngr"
 | | | | type "Employee"
 | | | | prop "name" H. G. Cunningham
 | | chain
 | end
```
This is emitting "code" that has lost the fact that we want an optional match.
```
{
  node: { bind: "mngr", type: "Employee", prop: [ "name", "H. G. Cunningham" ] },
  chain: {}
}
```
We hesitate here knowing we can emit whatever kind of code we want to apply with the desired semantic. This has been elusive.